### PR TITLE
Fix to unhappiness being unfairly applied to cities

### DIFF
--- a/Sources/CvUnit.cpp
+++ b/Sources/CvUnit.cpp
@@ -890,6 +890,8 @@ void CvUnit::reset(int iID, UnitTypes eUnit, PlayerTypes eOwner, bool bConstruct
 	// Toffer - UnitComponents
 	m_commander = NULL;
 	m_worker = NULL;
+
+	m_bInCityWhenKillDelay = false; // Not in a city by default
 }
 
 CvUnit& CvUnit::operator=(const CvUnit& other)
@@ -1589,6 +1591,7 @@ void CvUnit::killUnconditional(bool bDelay, PlayerTypes ePlayer, bool bMessaged)
 
 		if (bDelay)
 		{
+			pPlot->getPlotCity() ? m_bInCityWhenKillDelay = true : m_bInCityWhenKillDelay = false; // check if there is a city on a plot when unit gets killed
 			m_bDeathDelay = true;
 			return;
 		}
@@ -15736,7 +15739,7 @@ void CvUnit::setXY(int iX, int iY, bool bGroup, bool bUpdate, bool bShow, bool b
 
 		CvCity* pOldCity = pOldPlot->getPlotCity();
 
-		if (pOldCity)
+		if (pOldCity && (!isDelayedDeath() || (isDelayedDeath() && m_bInCityWhenKillDelay))) // If there is a city on old plot and death is delayed check if there was a city when death happend
 		{
 			if (isMilitaryHappiness())
 			{

--- a/Sources/CvUnit.h
+++ b/Sources/CvUnit.h
@@ -2042,6 +2042,8 @@ protected:
 	mutable std::map<FeatureTypes, FeatureKeyedInfo>		m_featureKeyedInfo;
 	mutable std::map<UnitCombatTypes, UnitCombatKeyedInfo>	m_unitCombatKeyedInfo;
 
+	bool m_bInCityWhenKillDelay; // wheter unit is in a city or not when kill is delayed
+
 	bool canAdvance(const CvPlot* pPlot, int iThreshold) const;
 	void collateralCombat(const CvPlot* pPlot, CvUnit* pSkipUnit = NULL);
 	void rBombardCombat(const CvPlot* pPlot, CvUnit* pFirstUnit = NULL);


### PR DESCRIPTION
When units are merged, there is kill delay and ai can in the meantime create city to which there is then unhappiness applied from reducing garrison.
